### PR TITLE
Corrected app name and fixed crashes.

### DIFF
--- a/DecoratedAppSceneView.h
+++ b/DecoratedAppSceneView.h
@@ -2,9 +2,10 @@
 #import "DecoratedFloatingView.h"
 
 @interface DecoratedAppSceneView : DecoratedFloatingView
-@property(nonatomic) _UIScenePresenter *presenter;
-@property(nonatomic) UIMutableApplicationSceneSettings *settings;
-@property(nonatomic) UIApplicationSceneTransitionContext *transitionContext;
+    @property(nonatomic) _UIScenePresenter *presenter;
+    @property(nonatomic) UIMutableApplicationSceneSettings *settings;
+    @property(nonatomic) UIApplicationSceneTransitionContext *transitionContext;
+    @property(nonatomic) NSString *sceneID;
 
-- (instancetype)initWithBundleID:(NSString *)bundleID;
+    - (instancetype)initWithBundleID:(LSApplicationProxy *)app;
 @end

--- a/DecoratedAppSceneView.m
+++ b/DecoratedAppSceneView.m
@@ -1,93 +1,99 @@
 #import "DecoratedAppSceneView.h"
 
 @implementation DecoratedAppSceneView
-- (instancetype)initWithBundleID:(NSString *)bundleID {
-    self = [super initWithFrame:CGRectMake(0, 100, 400, 400)];
-    self.transitionContext = [UIApplicationSceneTransitionContext new];
-    self.navigationBar.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-    [self.navigationBar.standardAppearance configureWithTransparentBackground];
-    self.navigationBar.standardAppearance.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
-    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose target:self action:@selector(closeWindow)];
+    - (instancetype)initWithBundleID:(LSApplicationProxy *)app{
+        self = [super initWithFrame:CGRectMake(0, 100, 400, 400)];
 
-    RBSProcessIdentity* identity = [RBSProcessIdentity identityForEmbeddedApplicationIdentifier:bundleID];
-    RBSProcessPredicate* predicate = [RBSProcessPredicate predicateMatchingIdentity:identity];
+        self.navigationBar.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+        [self.navigationBar.standardAppearance configureWithTransparentBackground];
+        self.navigationBar.standardAppearance.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose target:self action:@selector(closeWindow)];
 
-    FBProcessManager *manager = FBProcessManager.sharedInstance;
-    FBApplicationProcessLaunchTransaction *transaction = [[FBApplicationProcessLaunchTransaction alloc] initWithProcessIdentity:identity executionContextProvider:^id(void){
-        FBMutableProcessExecutionContext *context = [FBMutableProcessExecutionContext new];
-        context.identity = identity;
-        context.environment = @{}; // environment variables
-        //context.waitForDebugger = NO;
-        //context.disableASLR = NO;
-        context.launchIntent = 4;
-        //context.watchdogProvider = SBSceneWatchdogProvider
-        return [manager launchProcessWithContext:context];
-    }];
+        NSString *bundleID = app.bundleIdentifier;
+        self.transitionContext = [UIApplicationSceneTransitionContext new];
+        RBSProcessIdentity* identity = [RBSProcessIdentity identityForEmbeddedApplicationIdentifier:bundleID];
+        RBSProcessPredicate* predicate = [RBSProcessPredicate predicateMatchingIdentity:identity];
 
-    [transaction setCompletionBlock:^{
-        // At this point, the process is spawned and we're ready to create a scene to render in our app
-        RBSProcessHandle* processHandle = [RBSProcessHandle handleForPredicate:predicate error:nil];
-        [manager registerProcessForAuditToken:processHandle.auditToken];
-        NSString *identifier = [NSString stringWithFormat:@"sceneID:%@-%@", bundleID, @"default"];
+        FBProcessManager *manager = FBProcessManager.sharedInstance;
+        FBApplicationProcessLaunchTransaction *transaction = [[FBApplicationProcessLaunchTransaction alloc] initWithProcessIdentity:identity executionContextProvider:^id(void){
+            FBMutableProcessExecutionContext *context = [FBMutableProcessExecutionContext new];
+            context.identity = identity;
+            context.environment = @{}; // environment variables
+            //context.waitForDebugger = NO;
+            //context.disableASLR = NO;
+            context.launchIntent = 4;
+            //context.watchdogProvider = SBSceneWatchdogProvider
+            return [manager launchProcessWithContext:context];
+        }];
 
-        FBSMutableSceneDefinition *definition = [FBSMutableSceneDefinition definition];
-        definition.identity = [FBSSceneIdentity identityForIdentifier:identifier];
-        definition.clientIdentity = [FBSSceneClientIdentity identityForProcessIdentity:identity];
-        definition.specification = [UIApplicationSceneSpecification specification];
-        FBSMutableSceneParameters *parameters = [FBSMutableSceneParameters parametersForSpecification:definition.specification];
+        [transaction setCompletionBlock:^{
+            // At this point, the process is spawned and we're ready to create a scene to render in our app
+            RBSProcessHandle* processHandle = [RBSProcessHandle handleForPredicate:predicate error:nil];
+            [manager registerProcessForAuditToken:processHandle.auditToken];
+            // NSString *identifier = [NSString stringWithFormat:@"sceneID:%@-%@", bundleID, @"default"];
+            self.sceneID = [NSString stringWithFormat:@"sceneID:%@-%@", bundleID, @"default"];
 
-        UIMutableApplicationSceneSettings *settings = [UIMutableApplicationSceneSettings new];
-        settings.canShowAlerts = YES;
-        settings.cornerRadiusConfiguration = [[BSCornerRadiusConfiguration alloc] initWithTopLeft:self.layer.cornerRadius bottomLeft:self.layer.cornerRadius bottomRight:self.layer.cornerRadius topRight:self.layer.cornerRadius];
-        settings.displayConfiguration = UIScreen.mainScreen.displayConfiguration;
-        settings.foreground = YES;
-        settings.frame = self.bounds;
-        settings.interfaceOrientation = UIInterfaceOrientationPortrait;
-        //settings.interruptionPolicy = 2; // reconnect
-        settings.level = 1;
-        settings.peripheryInsets = UIEdgeInsetsMake(self.navigationBar.frame.size.height, 0, 0, 0);
-        settings.persistenceIdentifier = NSUUID.UUID.UUIDString;
-        settings.safeAreaInsetsPortrait = UIEdgeInsetsMake(self.navigationBar.frame.size.height, 0, 0, 0);
-        //settings.statusBarDisabled = 1;
-        //settings.previewMaximumSize = 
-        //settings.deviceOrientationEventsEnabled = YES;
-        self.settings = settings;
-        parameters.settings = settings;
 
-        UIMutableApplicationSceneClientSettings *clientSettings = [UIMutableApplicationSceneClientSettings new];
-        clientSettings.interfaceOrientation = UIInterfaceOrientationPortrait;
-        clientSettings.statusBarStyle = 0;
-        parameters.clientSettings = clientSettings;
+            FBSMutableSceneDefinition *definition = [FBSMutableSceneDefinition definition];
+            definition.identity = [FBSSceneIdentity identityForIdentifier:self.sceneID];
+            definition.clientIdentity = [FBSSceneClientIdentity identityForProcessIdentity:identity];
+            definition.specification = [UIApplicationSceneSpecification specification];
+            FBSMutableSceneParameters *parameters = [FBSMutableSceneParameters parametersForSpecification:definition.specification];
 
-        FBScene *scene = [[FBSceneManager sharedInstance] createSceneWithDefinition:definition initialParameters:parameters];
+            UIMutableApplicationSceneSettings *settings = [UIMutableApplicationSceneSettings new];
+            settings.canShowAlerts = YES;
+            settings.cornerRadiusConfiguration = [[BSCornerRadiusConfiguration alloc] initWithTopLeft:self.layer.cornerRadius bottomLeft:self.layer.cornerRadius bottomRight:self.layer.cornerRadius topRight:self.layer.cornerRadius];
+            settings.displayConfiguration = UIScreen.mainScreen.displayConfiguration;
+            settings.foreground = YES;
+            settings.frame = self.bounds;
+            settings.interfaceOrientation = UIInterfaceOrientationPortrait;
+            //settings.interruptionPolicy = 2; // reconnect
+            settings.level = 1;
+            settings.peripheryInsets = UIEdgeInsetsMake(self.navigationBar.frame.size.height, 0, 0, 0);
+            settings.persistenceIdentifier = NSUUID.UUID.UUIDString;
+            settings.safeAreaInsetsPortrait = UIEdgeInsetsMake(self.navigationBar.frame.size.height, 0, 0, 0);
+            //settings.statusBarDisabled = 1;
+            //settings.previewMaximumSize = 
+            //settings.deviceOrientationEventsEnabled = YES;
+            self.settings = settings;
+            parameters.settings = settings;
 
-        // TODO: get app display name
-        self.navigationItem.title = scene.clientProcess.name;
+            UIMutableApplicationSceneClientSettings *clientSettings = [UIMutableApplicationSceneClientSettings new];
+            clientSettings.interfaceOrientation = UIInterfaceOrientationPortrait;
+            clientSettings.statusBarStyle = 0;
+            parameters.clientSettings = clientSettings;
 
-        self.presenter = [scene.uiPresentationManager createPresenterWithIdentifier:identifier];
-        [self.presenter activate];
-        [self insertSubview:self.presenter.presentationView atIndex:0];
-    }];
-    [transaction begin];
-    return self;
-}
+            FBScene *scene = [[FBSceneManager sharedInstance] createSceneWithDefinition:definition initialParameters:parameters];
 
-- (void)closeWindow {
-    self.layer.masksToBounds = NO;
-    [UIView transitionWithView:self duration:0.4 options:UIViewAnimationOptionTransitionCurlUp //CrossDissolve
-    animations:^{
-        self.hidden = YES;
-    } completion:^(BOOL b){
-        [self.presenter deactivate];
-        [self.presenter invalidate];
-        [self removeFromSuperview];
-    }];
-}
+            self.navigationItem.title = app.localizedName;
 
-- (void)resizeWindow:(UIPanGestureRecognizer*)sender {
-    [super resizeWindow:sender];
+            self.presenter = [scene.uiPresentationManager createPresenterWithIdentifier:self.sceneID];
+            [self.presenter activate];
+            [self insertSubview:self.presenter.presentationView atIndex:0];
+        }];
+        [transaction begin];
+        return self;
+    }
 
-    self.settings.frame = self.bounds;
-    [self.presenter.scene updateSettings:self.settings withTransitionContext:self.transitionContext completion:nil];
-}
+    - (void)closeWindow {
+        self.layer.masksToBounds = NO;
+        [UIView transitionWithView:self duration:0.4 options:UIViewAnimationOptionTransitionCurlUp animations:^{
+            self.hidden = YES;
+        } completion:^(BOOL b){
+            [[FBSceneManager sharedInstance] destroyScene:self.sceneID withTransitionContext:nil];
+            if(self.presenter){
+                [self.presenter deactivate];
+                [self.presenter invalidate];
+                self.presenter = nil;
+            }
+            [self removeFromSuperview];
+        }];
+    }
+
+    - (void)resizeWindow:(UIPanGestureRecognizer*)sender {
+        [super resizeWindow:sender];
+
+        self.settings.frame = self.bounds;
+        [self.presenter.scene updateSettings:self.settings withTransitionContext:self.transitionContext completion:nil];
+    }
 @end

--- a/LauncherViewController.m
+++ b/LauncherViewController.m
@@ -7,58 +7,62 @@
 @end
 
 @implementation LauncherViewController
+    -(void)loadView {
+        [super loadView];
+        self.view.backgroundColor = UIColor.systemBackgroundColor;
+        self.title = @"FrontBoardAppLauncher";
 
-- (void)loadView {
-    [super loadView];
-    self.view.backgroundColor = UIColor.systemBackgroundColor;
-    self.title = @"FrontBoardAppLauncher";
-
-    self.apps = LSApplicationWorkspace.defaultWorkspace.allInstalledApplications.mutableCopy;
-    [self.apps sortUsingDescriptors:@[
-        [NSSortDescriptor sortDescriptorWithKey:@"localizedShortName" ascending:YES],
-    ]];
-}
-
-- (UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSString *cellID = @"Cell";
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellID];
-    if (cell == nil) {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:cellID];
+        self.apps = [[NSMutableArray alloc] init];
+        NSArray *app_list = [LSApplicationWorkspace.defaultWorkspace allInstalledApplications];
+        for (LSApplicationProxy *app in app_list) {
+                if ([app.applicationType isEqual:@"User"] || ([app.applicationType isEqual:@"System"] && ![app.appTags containsObject:@"hidden"] && !app.launchProhibited && !app.placeholder && !app.removedSystemApp)) {
+                    [self.apps addObject:app];
+                }
+        }
+        [self.apps sortUsingDescriptors:@[
+            [NSSortDescriptor sortDescriptorWithKey:@"localizedName" ascending:YES],
+        ]];
     }
 
-    cell.textLabel.text = self.apps[indexPath.row].localizedShortName;
-    cell.detailTextLabel.text = self.apps[indexPath.row].bundleIdentifier;
-    cell.imageView.image = [UIImage _applicationIconImageForBundleIdentifier:cell.detailTextLabel.text format:0 scale:UIScreen.mainScreen.scale];
-    return cell;
-}
+    -(UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+        NSString *cellID = @"Cell";
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellID];
+        if (cell == nil) {
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:cellID];
+        }
 
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    [tableView deselectRowAtIndexPath:indexPath animated:NO];
-    DecoratedAppSceneView *view = [[DecoratedAppSceneView alloc] initWithBundleID:self.apps[indexPath.row].bundleIdentifier];
-    CGRect origFrame = view.frame;
-    CGRect cellFrame = view.frame;
+        cell.textLabel.text = self.apps[indexPath.row].localizedName;
+        cell.detailTextLabel.text = self.apps[indexPath.row].bundleIdentifier;
+        cell.imageView.image = [UIImage _applicationIconImageForBundleIdentifier:cell.detailTextLabel.text format:0 scale:UIScreen.mainScreen.scale];
+        return cell;
+    }
 
-    UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
-    cellFrame.origin = [cell.superview convertPoint:cell.frame.origin toView:self.navigationController.parentViewController.view];
-    cellFrame.size = cell.frame.size;
+    -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+        [tableView deselectRowAtIndexPath:indexPath animated:NO];
+        DecoratedAppSceneView *view = [[DecoratedAppSceneView alloc] initWithBundleID:self.apps[indexPath.row]];
+        CGRect origFrame = view.frame;
+        CGRect cellFrame = view.frame;
 
-    view.alpha = 0;
-    view.frame = cellFrame;
-    view.backgroundColor = [UIColor blackColor];
-    [self.navigationController.parentViewController.view addSubview:view];
-    [UIView animateWithDuration:0.4
-    animations:^{
-        view.alpha = 1;
-        view.frame = origFrame;
-    } completion:nil];
-}
+        UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
+        cellFrame.origin = [cell.superview convertPoint:cell.frame.origin toView:self.navigationController.parentViewController.view];
+        cellFrame.size = cell.frame.size;
 
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 1;
-}
+        view.alpha = 0;
+        view.frame = cellFrame;
+        view.backgroundColor = [UIColor blackColor];
+        [self.navigationController.parentViewController.view addSubview:view];
+        [UIView animateWithDuration:0.4
+        animations:^{
+            view.alpha = 1;
+            view.frame = origFrame;
+        } completion:nil];
+    }
 
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return self.apps.count;
-}
+    -(NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+        return 1;
+    }
 
+    -(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+        return self.apps.count;
+    }
 @end

--- a/UIKitPrivate.h
+++ b/UIKitPrivate.h
@@ -4,10 +4,24 @@ typedef struct {
 	unsigned val[8];
 } SCD_Struct_RB3;
 
-@interface LSApplicationProxy : NSObject
-@property(nonatomic, assign, readonly) NSString *bundleIdentifier;
-@property(nonatomic, assign, readonly) NSString *localizedShortName;
-@property(nonatomic, assign, readonly) NSString *primaryIconName;
+@interface LSResourceProxy : NSObject
+	@property (setter=_setLocalizedName:,nonatomic,copy) NSString *localizedName;
+@end
+
+@interface LSBundleProxy : LSResourceProxy
+@end
+
+@interface LSApplicationProxy : LSBundleProxy
+	@property(nonatomic, assign, readonly) NSString *bundleIdentifier;
+	@property(nonatomic, assign, readonly) NSString *localizedShortName;
+	@property(nonatomic, assign, readonly) NSString *primaryIconName;
+
+	@property (nonatomic,readonly) NSString * applicationIdentifier;
+	@property (nonatomic,readonly) NSString * applicationType;
+	@property (nonatomic,readonly) NSArray * appTags;
+	@property (getter=isLaunchProhibited,nonatomic,readonly) BOOL launchProhibited;
+	@property (getter=isPlaceholder,nonatomic,readonly) BOOL placeholder;
+	@property (getter=isRemovedSystemApp,nonatomic,readonly) BOOL removedSystemApp;
 @end
 
 @interface LSApplicationWorkspace : NSObject
@@ -153,6 +167,7 @@ typedef struct {
 @interface FBSceneManager : NSObject
 + (instancetype)sharedInstance;
 - (FBScene *)createSceneWithDefinition:(id)def initialParameters:(id)params;
+-(void)destroyScene:(id)arg1 withTransitionContext:(id)arg2 ;
 @end
 
 @interface UIImage(internal)
@@ -168,12 +183,12 @@ typedef struct {
 @property(nonatomic, assign) NSInteger statusBarStyle;
 @end
 
-@interface UIWindow(private)
+@interface UIWindow (Private)
 - (instancetype)_initWithFrame:(CGRect)frame attached:(BOOL)attached;
 - (void)orderFront:(id)arg1;
 @end
 
-@interface UIScreen(private)
+@interface UIScreen (Private)
 - (CGRect)_referenceBounds;
 - (id)displayConfiguration;
 @end


### PR DESCRIPTION
// TODO: get app display name
self.navigationItem.title = scene.clientProcess.name;

//Corrected to put the correct app name.
self.navigationItem.title = app.localizedName;


//TODO:Re-opening an app after closing may crash

//Fix by adding the following code.
[[FBSceneManager sharedInstance] destroyScene:self.sceneID withTransitionContext:nil];